### PR TITLE
TabBar的clipsToBounds情况：子view超出部分没有显示出来，则子view不应该得到响应

### DIFF
--- a/CYLTabBarController/CYLTabBar.m
+++ b/CYLTabBarController/CYLTabBar.m
@@ -259,6 +259,10 @@ static void *const CYLTabBarContext = (void*)&CYLTabBarContext;
     
     //2. 优先处理 PlusButton （包括其突出的部分）、TabBarItems 未凸出的部分
     //这一步主要是在处理只有两个 TabBarItems 的场景。
+    // 2.1先考虑clipsToBounds情况：子view超出部分没有显示出来
+    if (self.clipsToBounds && ![self pointInside:point withEvent:event]) {
+        return nil;
+    }
     
     if (CYLExternPlusButton) {
         CGRect plusButtonFrame = self.plusButton.frame;


### PR DESCRIPTION
另外下面的代码，直接使用CGRectContainsPoint判断的话，少了对CYLExternPlusButton的`self.hidden || (self.alpha <= 0.01f) || (self.userInteractionEnabled == NO)`的判断

```
if (CYLExternPlusButton) {
        CGRect plusButtonFrame = self.plusButton.frame;
        BOOL isInPlusButtonFrame = CGRectContainsPoint(plusButtonFrame, point);
        if (isInPlusButtonFrame) {
            return CYLExternPlusButton;
        }
}
```

继续采用`- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event`进行判断，更合理一点