### PR TITLE
Update CYLPlusButton.m

### DIFF
--- a/CYLTabBarController/CYLPlusButton.m
+++ b/CYLTabBarController/CYLPlusButton.m
@@ -72,5 +72,11 @@ UIViewController *CYLPlusChildViewController = nil;
     }];
     [plusButton addTarget:plusButton action:@selector(plusChildViewControllerButtonClicked:) forControlEvents:UIControlEventTouchUpInside];
 }
+/*!
+ *  按钮选中状态下点击先显示normal状态的颜色，松开时再回到selected状态下颜色。
+ *  重写此方法即不会出现上述情况，与UITabBarButton相似
+ */
+- (void)setHighlighted:(BOOL)highlighted{
 
+}
 @end


### PR DESCRIPTION
Plus按钮选中状态下点击先显示normal状态的颜色，松开时再回到selected状态下颜色。
重写highlighted此方法即不会出现上述情况，与UITabBarButton相似

## My issue:
<!--- Please describe which issue do you want to fix. -->

## What I have done:

<!--- Please mention me to merge with wechat:chenyilong1010 -->

