### PR TITLE
修复12.1beta版本pop回来tabbarItem上移

### DIFF
--- a/CYLTabBarController/CYLTabBar.m
+++ b/CYLTabBarController/CYLTabBar.m
@@ -10,6 +10,24 @@
 #import "CYLPlusButton.h"
 #import "CYLTabBarController.h"
 
+/**
+ *  用 block 重写某个 class 的指定方法
+ *  @param targetClass 要重写的 class
+ *  @param targetSelector 要重写的 class 里的实例方法，注意如果该方法不存在于 targetClass 里，则什么都不做
+ *  @param implementationBlock 该 block 必须返回一个 block，返回的 block 将被当成 targetSelector 的新实现，所以要在内部自己处理对 super 的调用，以及对当前调用方法的 self 的 class 的保护判断（因为如果 targetClass 的 targetSelector 是继承自父类的，targetClass 内部并没有重写这个方法，则我们这个函数最终重写的其实是父类的 targetSelector，所以会产生预期之外的 class 的影响，例如 targetClass 传进来  UIButton.class，则最终可能会影响到 UIView.class），implementationBlock 的参数里第一个为你要修改的 class，也即等同于 targetClass，第二个参数为你要修改的 selector，也即等同于 targetSelector，第三个参数是 targetSelector 原本的实现，由于 IMP 可以直接当成 C 函数调用，所以可利用它来实现“调用 super”的效果，但由于 targetSelector 的参数个数、参数类型、返回值类型，都会影响 IMP 的调用写法，所以这个调用只能由业务自己写。
+ */
+CG_INLINE BOOL
+OverrideImplementation(Class targetClass, SEL targetSelector, id (^implementationBlock)(Class originClass, SEL originCMD, IMP originIMP)) {
+    Method originMethod = class_getInstanceMethod(targetClass, targetSelector);
+    if (!originMethod) {
+        return NO;
+    }
+    IMP originIMP = method_getImplementation(originMethod);
+    method_setImplementation(originMethod, imp_implementationWithBlock(implementationBlock(targetClass, targetSelector, originIMP)));
+    return YES;
+}
+
+
 static void * const CYLTabBarContext = (void*)&CYLTabBarContext;
 
 @interface CYLTabBar ()
@@ -20,6 +38,34 @@ static void * const CYLTabBarContext = (void*)&CYLTabBarContext;
 @end
 
 @implementation CYLTabBar
+    
++ (void)load
+{
+    /* 这个问题是 iOS 12.1 Beta 2 的问题，只要 UITabBar 是磨砂的，并且 push viewController 时 hidesBottomBarWhenPushed = YES 则手势返回的时候就会触发。
+    
+    出现这个现象的直接原因是 tabBar 内的按钮 UITabBarButton 被设置了错误的 frame，frame.size 变为 (0, 0) 导致的。如果12.1正式版Apple修复了这个bug可以移除调这段代码(来源于QMUIKit的处理方式)*/
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+            if (@available(iOS 12.1, *)) {
+                OverridImplementation(NSClassFromString(@"UITabBarButton"), @selector(setFrame:), ^id(__unsafe_unretained Class originClass, SEL originCMD, IMP originIMP) {
+                    return ^(UIView *selfObject, CGRect firstArgv) {
+    
+                        if ([selfObject isKindOfClass:originClass]) {
+                            // 如果发现即将要设置一个 size 为空的 frame，则屏蔽掉本次设置
+                            if (!CGRectIsEmpty(selfObject.frame) && CGRectIsEmpty(firstArgv)) {
+                                return;
+                            }
+                        }
+    
+                        // call super
+                        void (*originSelectorIMP)(id, SEL, CGRect);
+                        originSelectorIMP = (void (*)(id, SEL, CGRect))originIMP;
+                        originSelectorIMP(selfObject, originCMD, firstArgv);
+                    };
+                });
+            }
+    });
+}
 
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];

--- a/CYLTabBarController/CYLTabBar.m
+++ b/CYLTabBarController/CYLTabBar.m
@@ -47,7 +47,7 @@ static void * const CYLTabBarContext = (void*)&CYLTabBarContext;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
             if (@available(iOS 12.1, *)) {
-                OverridImplementation(NSClassFromString(@"UITabBarButton"), @selector(setFrame:), ^id(__unsafe_unretained Class originClass, SEL originCMD, IMP originIMP) {
+                OverrideImplementation(NSClassFromString(@"UITabBarButton"), @selector(setFrame:), ^id(__unsafe_unretained Class originClass, SEL originCMD, IMP originIMP) {
                     return ^(UIView *selfObject, CGRect firstArgv) {
     
                         if ([selfObject isKindOfClass:originClass]) {


### PR DESCRIPTION
这个问题是 iOS 12.1 Beta 2 的问题，只要 UITabBar 是磨砂的，并且 push viewController 时 hidesBottomBarWhenPushed = YES 则手势返回的时候就会触发。
    
    出现这个现象的直接原因是 tabBar 内的按钮 UITabBarButton 被设置了错误的 frame，frame.size 变为 (0, 0) 导致的。如果12.1正式版Apple修复了这个bug可以移除调这段代码(来源于QMUIKit的处理方式),如果12.1正式版本Apple Fix了这个bug,可以移除掉这个bug

## My issue:
<!--- Please describe which issue do you want to fix. -->

## What I have done:

<!--- Please mention me to merge with wechat:chenyilong1010 -->

