### PR TITLE
fix: 修正TabbarButton的cyl_isSelected状态

### DIFF
--- a/CYLTabBarController/UIControl+CYLTabBarControllerExtention.m
+++ b/CYLTabBarController/UIControl+CYLTabBarControllerExtention.m
@@ -72,12 +72,11 @@
 }
 
 - (BOOL)cyl_isSelected {
-    BOOL isSelected = NO;
     NSUInteger tabBarSelectedIndex = self.cyl_tabBarController.selectedIndex;
     NSUInteger tabBarChildViewControllerIndex = self.cyl_tabBarChildViewControllerIndex;
-    BOOL defaultSelected = self.selected;
-    if ((tabBarSelectedIndex == tabBarChildViewControllerIndex) && defaultSelected && CYLPlusChildViewController.cyl_plusViewControllerEverAdded) {
-        isSelected = YES;
+    BOOL isSelected = (tabBarSelectedIndex == tabBarChildViewControllerIndex) && self.selected;
+    if (self.cyl_tabBarController.tabBar.cyl_hasPlusChildViewController) {
+        isSelected = isSelected && CYLPlusChildViewController.cyl_plusViewControllerEverAdded;
     }
     return isSelected;
 }


### PR DESCRIPTION
选中状态下再次点击时重复播放lottie动画 #529

