### PR TITLE
fix: 🐛 remove private selector allowsHitTesting usage

### DIFF
--- a/CYLTabBarController/UIView+CYLTabBarControllerExtention.h
+++ b/CYLTabBarController/UIView+CYLTabBarControllerExtention.h
@@ -14,7 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic) __weak UIView * _Nullable sourceView;
 @property(nonatomic) _Bool forwardsClientHitTestingToSourceView;
-@property(nonatomic) _Bool allowsHitTesting; // @dynamic allowsHitTesting;
 @property(nonatomic) _Bool allowsBackdropGroups; // @dynamic allowsBackdropGroups;
 @property(nonatomic) _Bool matchesPosition; // @dynamic matchesPosition;
 @property(nonatomic) _Bool matchesTransform; // @dynamic matchesTransform;

--- a/CYLTabBarController/UIView+CYLTabBarControllerExtention.m
+++ b/CYLTabBarController/UIView+CYLTabBarControllerExtention.m
@@ -88,6 +88,8 @@
         view.forwardsClientHitTestingToSourceView = false;
     }
     view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    // 使用公开 API，确保 PortalView 不参与命中测试，避免遮挡 TabBar 点击。
+    view.userInteractionEnabled = NO;
 
     view.sourceView = sourceView;
     view.sourceView.bounds = sourceView.bounds;
@@ -95,9 +97,6 @@
     view.matchesPosition = matchPosition;
     view.matchesTransform = matchPosition;
     view.matchesAlpha = false;
-    if (@available(iOS 14.0, *)) {
-        view.allowsHitTesting = false;
-    }
     
 //    UIView *superview = view.superview;
 //    if (superview) {
@@ -878,4 +877,3 @@ CYL_DEPRECATED_IGNORED_IMPLEMENTATIONS_POP
 
 
 @end
-


### PR DESCRIPTION
## Summary
- remove `allowsHitTesting` property declaration from `UIKitPortalViewProtocol`
- remove private selector call `view.allowsHitTesting = false`
- use public API `view.userInteractionEnabled = NO` to keep portal view non-interactive

## Why
Apple review reported ITMS-90338 for non-public selector usage: `setAllowsHitTesting:`.

## Impact
- avoids embedding private selector names in app binary
- preserves intended behavior (portal view should not intercept touch events)